### PR TITLE
Add function for SCRIPT_NAME-aware redirects.

### DIFF
--- a/ProxyMiddleware/ProxyMiddleware.py
+++ b/ProxyMiddleware/ProxyMiddleware.py
@@ -74,6 +74,9 @@ def force_slash(fn):
             redirect(request.environ['SCRIPT_NAME'] + request.environ['PATH_INFO'] + '/')
     return wrapped
 
+def script_name_redirect(url):
+    redirect(request.environ['SCRIPT_NAME'] + url)
+
 class AddHeaderPlugin(object):
     name = "AddHeaderPlugin"
     api = 2


### PR DESCRIPTION
There doesn't seem to be a clean way to do clean absolute redirects to routes within an application with the stock `redirect` function when it's mounted under a non-`/` SCRIPT_NAME. This function adds the ability to do that without the application needing to dig into `request.environ`.
